### PR TITLE
Fixes Windows service stop

### DIFF
--- a/main_windows.go
+++ b/main_windows.go
@@ -111,7 +111,6 @@ func main() {
 	inService, err := svc.IsWindowsService()
 	if err != nil {
 		os.Exit(99) // failed to determine service status
-		return
 	}
 
 	// running as service?
@@ -119,8 +118,8 @@ func main() {
 		err := svc.Run("cloud-sql-proxy", &windowsService{})
 		if err != nil {
 			os.Exit(100) // failed to execute service
-			return
 		}
+		return
 	}
 
 	// run as commandline


### PR DESCRIPTION
When the Windows service stops, it immediately spawns a command line instance with the same arguments. This rebinds to the same port(s) and effectively prevents the service from stopping or restarting.